### PR TITLE
Reconfigured AR render logic on button press in VisionAR

### DIFF
--- a/js/helpers/tester.js
+++ b/js/helpers/tester.js
@@ -1,4 +1,3 @@
-'use strict';
 
 import React from "react";
 
@@ -30,7 +29,6 @@ export function Target(type, name) {
                     opacity={0.0}
                     scale={[0.0, 0.0, 0.0]}
                     materials={["apple"]}
-                    key={dummyKey}
                     animation={{
                         name: 'plswrk', delay: 3000, run: true
                     }} />
@@ -55,7 +53,7 @@ const dummyKeyGen = () => {
 
 }
 
-export const renderables = {
+export let renderables = {
     data: [],
     hasBeenFilled: false
 };

--- a/js/scenes/Landing.js
+++ b/js/scenes/Landing.js
@@ -185,19 +185,17 @@ export default class Landing extends Component {
     }
     _toggleTargeting() {
         if (!this.state.trackingActive) {
-            fillAndRender();
+            
             let newState = {...this.state};
             newState.trackingActive = true;
             this.setState(newState);
+            fillAndRender();
         }
         else {
-            emptyTracker();
             let newState = {...this.state};
             newState.trackingActive = false;
             this.setState(newState);
-            setTimeout(()=> {
-                alert("Tracker has been emptied");
-            },1500)
+            emptyTracker();
         }
 
     }

--- a/js/scenes/VisionAR.js
+++ b/js/scenes/VisionAR.js
@@ -44,9 +44,9 @@ class VisionAR extends Component {
         // Set initial state here
         this.state = {
             text: "Initializing AR...",
-            testText: "THeyyyyyyyyyy",
+            testText: "Click the pink circle after initializing tracking",
             playAnim: false,
-            trackerEmpty: true,
+            canRenderARComponents : false,
             targets: []
         };
 
@@ -109,14 +109,14 @@ class VisionAR extends Component {
                 newState.targets.push(renderables.data[i]);
             }
         }
+        
         this.setState(newState);
     }
     checkIfRenderablesEmpty = () => {
         setInterval(() => {
             if(!renderables.hasBeenFilled && this.state.targets.length > 1){
-                alert('Scene will now refresh')
+                //alert('Scene will now refresh')
                 let newState = {...this.state};
-                newState.trackerEmpty = true;
                 newState.targets = [];
                 this.setState(newState);
             }else{
@@ -124,9 +124,16 @@ class VisionAR extends Component {
             }
         }, 1000);
     }
+    grabRenderables = () => {
 
+        if(this.state.targets.length > 1){
+            let ARtargets = this.state.targets.map( target => target );
+            return ARtargets;
+        }
+
+    }
     render() {
-    let ARtargets = this.state.targets.map( target => target );
+    
           
         
         return (
@@ -137,8 +144,7 @@ class VisionAR extends Component {
                 thing={this.state.testText}
                 onClick={this.bake}
                 />
-
-                {ARtargets}
+                {this.grabRenderables()}
             
             </ViroARScene>
         );

--- a/models/trackingTargets.js
+++ b/models/trackingTargets.js
@@ -1,10 +1,9 @@
-'use strict'
 
 import React from "react";
 import { renderables, Target } from "../js/helpers/tester"
 import { ViroARTrackingTargets } from "react-viro";
 
-export const targets =
+let targets =
 {
     "apple": {
         source: require('../js/res/apple.jpg'),
@@ -23,34 +22,44 @@ export const targets =
     }
 }
 
+const initializationTracker = {
+    trackersAlreadyMade : false
+}
+
 export function emptyTracker() {
-    for (let x in targets) {
+    /* for (let x in targets) {
         ViroARTrackingTargets.deleteTarget(x);
-    }
+    } */
+
+    renderables.data = [];
     renderables.hasBeenFilled = false;
+    
 }
 
 export function fillAndRender() {
-    fillTracker.then(() => setTimeout(() => {
-        renderTrackers();
-    }, 1500)
-
-    ).catch((err) => alert('Something went wrong. Rendering failed'));
+    fillTracker(targets);
+    setTimeout( () => {
+        renderTrackers()
+    }, 1000);
+        
 }
 
 
 
-const fillTracker = new Promise(function (resolve, reject) {
-    //alert(JSON.stringify(targets));
-    resolve(ViroARTrackingTargets.createTargets(targets));
+const fillTracker = (obj) => {
 
-});
+    if(!initializationTracker.trackersAlreadyMade){
+        ViroARTrackingTargets.createTargets(obj);
+        initializationTracker.trackersAlreadyMade = true;
+    }
+    
+}
+
 
 function renderTrackers() {
     for (let x in targets) {
         Target("box", x);
 
-        //alert(x);
     }
 }
 


### PR DESCRIPTION
- The 'deleteTargets' method from Viro wasn't behaving as expected,
- Resorted to creating logic that refreshes the AR scene since it makes no difference to each components' animation playback  if the targets have already been created in the backend.